### PR TITLE
FFS-2233 Add telemetry rollout for archive gateway

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,9 +35,10 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-reflect")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
-    implementation("no.novari:flyt-kafka:7.2.0")
+    implementation("no.novari:flyt-kafka:7.3.0-rc-2")
     implementation("no.novari:flyt-cache:3.0.0")
-    implementation("no.novari:flyt-web-resource-server:4.0.0")
+    implementation("no.novari:flyt-web-resource-server:4.1.0-rc-2")
+    implementation("no.novari:telemetry-starter:0.0.4")
 
     implementation("no.novari:fint-arkiv-resource-model-java:$fintResourceModelVersion")
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+    implementation("io.github.oshai:kotlin-logging-jvm:8.0.4")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     implementation("no.novari:flyt-kafka:7.3.0-rc-2")
@@ -44,6 +45,7 @@ dependencies {
     implementation("no.novari:fint-administrasjon-resource-model-java:$fintResourceModelVersion")
 
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    runtimeOnly("net.logstash.logback:logstash-logback-encoder:9.0")
 
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.mockito.kotlin:mockito-kotlin:6.1.0")

--- a/kustomize/overlays/afk-no/api/kustomization.yaml
+++ b/kustomize/overlays/afk-no/api/kustomization.yaml
@@ -54,6 +54,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/afk-no"
       - op: replace

--- a/kustomize/overlays/afk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/afk-no/beta/kustomization.yaml
@@ -54,6 +54,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "afk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/afk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/agderfk-no"
       - op: replace

--- a/kustomize/overlays/agderfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/agderfk-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "agderfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/agderfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/api/kustomization.yaml
@@ -54,6 +54,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/bfk-no"
       - op: replace

--- a/kustomize/overlays/bfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/bfk-no/beta/kustomization.yaml
@@ -54,6 +54,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/bfk-no"
       - op: replace

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,14 +7,14 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-archive-gateway_bym-oslo-kommune-no
+      app.kubernetes.io/instance: fint-flyt-archive-gateway_bym_oslo_kommune_no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
   - patch: |-
       - op: replace
         path: "/metadata/labels/app.kubernetes.io~1instance"
-        value: "fint-archive-gateway_bym-oslo-kommune-no"
+        value: "fint-archive-gateway_bym_oslo_kommune_no"
       - op: replace
         path: "/spec/kafka/acls/0/topic"
         value: "bym-oslo-kommune-no.flyt.*"
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "bym.oslo.kommune.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/bym-oslo-kommune-no"
       - op: replace
@@ -74,7 +79,7 @@ patches:
   - patch: |-
       - op: replace
         path: "/metadata/labels/app.kubernetes.io~1instance"
-        value: "fint-flyt-archive-fint-client_bym-oslo-kommune-no"
+        value: "fint-flyt-archive-fint-client_bym_oslo_kommune_no"
       - op: replace
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -7,14 +7,14 @@ resources:
 
 labels:
   - pairs:
-      app.kubernetes.io/instance: fint-flyt-archive-gateway_bym_oslo_kommune_no
+      app.kubernetes.io/instance: fint-flyt-archive-gateway_bym-oslo-kommune-no
       fintlabs.no/org-id: bym.oslo.kommune.no
 
 patches:
   - patch: |-
       - op: replace
         path: "/metadata/labels/app.kubernetes.io~1instance"
-        value: "fint-archive-gateway_bym_oslo_kommune_no"
+        value: "fint-archive-gateway_bym-oslo-kommune-no"
       - op: replace
         path: "/spec/kafka/acls/0/topic"
         value: "bym-oslo-kommune-no.flyt.*"
@@ -79,7 +79,7 @@ patches:
   - patch: |-
       - op: replace
         path: "/metadata/labels/app.kubernetes.io~1instance"
-        value: "fint-flyt-archive-fint-client_bym_oslo_kommune_no"
+        value: "int-flyt-archive-fint-client_bym-oslo-kommune-no"
       - op: replace
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"

--- a/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
+++ b/kustomize/overlays/bym-oslo-kommune-no/api/kustomization.yaml
@@ -79,7 +79,7 @@ patches:
   - patch: |-
       - op: replace
         path: "/metadata/labels/app.kubernetes.io~1instance"
-        value: "int-flyt-archive-fint-client_bym-oslo-kommune-no"
+        value: "fint-flyt-archive-fint-client_bym-oslo-kommune-no"
       - op: replace
         path: "/spec/orgId"
         value: "bym.oslo.kommune.no"

--- a/kustomize/overlays/ffk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/ffk-no"
       - op: replace

--- a/kustomize/overlays/ffk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ffk-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ffk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/ffk-no"
       - op: replace

--- a/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
+++ b/kustomize/overlays/fintlabs-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "fintlabs.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/fintlabs-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/innlandetfylke-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "innlandetfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/innlandetfylke-no"
       - op: replace

--- a/kustomize/overlays/mrfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/mrfylke-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "mrfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/mrfylke-no"
       - op: replace

--- a/kustomize/overlays/nfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/nfk-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "nfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/nfk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/api/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/api/kustomization.yaml
@@ -54,6 +54,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/ofk-no"
       - op: replace

--- a/kustomize/overlays/ofk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/ofk-no/beta/kustomization.yaml
@@ -54,6 +54,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "ofk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/ofk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/rogfk-no"
       - op: replace

--- a/kustomize/overlays/rogfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/rogfk-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "rogfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/rogfk-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/telemarkfylke-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "telemarkfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/telemarkfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/tromsfylke-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "tromsfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/tromsfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/trondelagfylke-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "trondelagfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/trondelagfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vestfoldfylke-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vestfoldfylke.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/vestfoldfylke-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/api/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/api/kustomization.yaml
@@ -53,6 +53,11 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/vlfk-no"
       - op: replace

--- a/kustomize/overlays/vlfk-no/beta/kustomization.yaml
+++ b/kustomize/overlays/vlfk-no/beta/kustomization.yaml
@@ -53,6 +53,16 @@ patches:
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "vlfk.no"
+      - op: add
+        path: "/spec/env/-"
+        value:
+          name: "OTEL_EXPORTER_OTLP_ENDPOINT"
+          value: "http://alloy.flais-system.svc.cluster.local:4318"
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "/beta/vlfk-no"
       - op: add

--- a/kustomize/templates/overlay.yaml.tpl
+++ b/kustomize/templates/overlay.yaml.tpl
@@ -49,6 +49,11 @@ $AUTHORIZED_ORG_ROLE_PAIRS
       - op: add
         path: "/spec/env/-"
         value:
+          name: "novari.telemetry.org-id"
+          value: "$ORG_ID"$OTEL_ENV_PATCH
+      - op: add
+        path: "/spec/env/-"
+        value:
           name: "server.servlet.context-path"
           value: "$SERVLET_CONTEXT_PATH"$EXTRA_ENV_PATCHES
       - op: replace

--- a/script/render-overlay.sh
+++ b/script/render-overlay.sh
@@ -10,6 +10,21 @@ FINT_CLIENT_NAME="fint-flyt-archive-fint-client"
 USER_ROLE="USER"
 DEVELOPER_ROLE="DEVELOPER"
 
+OTEL_ENDPOINT_BETA="http://alloy.flais-system.svc.cluster.local:4318"
+
+# Base-URL uten /v1/traces: telemetry-starter legger på signal-stien selv.
+# Settes manuelt inntil flaiserator har støtte for det, og kun i beta der Alloy kjører.
+build_otel_env_patch() {
+  local env_path="$1"
+
+  if [[ "$env_path" != "beta" ]]; then
+    return
+  fi
+
+  printf '\n      - op: add\n        path: "/spec/env/-"\n        value:\n          name: "OTEL_EXPORTER_OTLP_ENDPOINT"\n          value: "%s"' \
+    "$OTEL_ENDPOINT_BETA"
+}
+
 extra_user_orgs_for_namespace() {
   local namespace="$1"
   case "$namespace" in
@@ -137,6 +152,7 @@ while IFS= read -r file; do
   export LIVENESS_PATH="${path_prefix}/actuator/health/liveness"
   export METRICS_PATH="${path_prefix}/actuator/prometheus"
   export EXTRA_ENV_PATCHES="$(render_extra_env_patches "$namespace" "$env_path")"
+  export OTEL_ENV_PATCH="$(build_otel_env_patch "$env_path")"
   if ((${#additional_user_orgs[@]})); then
     AUTHORIZED_ORG_ROLE_PAIRS="$(render_authorized_role_pairs "$ORG_ID" "${additional_user_orgs[@]}")"
   else
@@ -151,7 +167,7 @@ while IFS= read -r file; do
   target_dir="$ROOT/kustomize/overlays/$dir"
 
   tmp="$(mktemp "$target_dir/.kustomization.yaml.XXXXXX")"
-  envsubst '$APPLICATION_NAME $APPLICATION_PATCH_LABEL $NAMESPACE $APP_INSTANCE_LABEL $ORG_ID $KAFKA_TOPIC $INGRESS_BASE_PATH $ARCHIVE_BASE_URL $AUTHORIZED_ORG_ROLE_PAIRS $ONEPASSWORD_ITEM_PATH $STARTUP_PATH $READINESS_PATH $LIVENESS_PATH $METRICS_PATH $FINT_CLIENT_NAME $FINT_CLIENT_INSTANCE_LABEL $NOVARI_KAFKA_TOPIC_ORGID $SERVLET_CONTEXT_PATH $EXTRA_ENV_PATCHES' \
+  envsubst '$APPLICATION_NAME $APPLICATION_PATCH_LABEL $NAMESPACE $APP_INSTANCE_LABEL $ORG_ID $KAFKA_TOPIC $INGRESS_BASE_PATH $ARCHIVE_BASE_URL $AUTHORIZED_ORG_ROLE_PAIRS $ONEPASSWORD_ITEM_PATH $STARTUP_PATH $READINESS_PATH $LIVENESS_PATH $METRICS_PATH $FINT_CLIENT_NAME $FINT_CLIENT_INSTANCE_LABEL $NOVARI_KAFKA_TOPIC_ORGID $SERVLET_CONTEXT_PATH $EXTRA_ENV_PATCHES $OTEL_ENV_PATCH' \
     < "$template" > "$tmp"
   mv "$tmp" "$target_dir/kustomization.yaml"
 done < <(find "$ROOT/kustomize/overlays" -name kustomization.yaml -print | sort)

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/WebUtilErrorHandler.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/WebUtilErrorHandler.kt
@@ -1,7 +1,7 @@
 package no.novari.flyt.archive.gateway
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.slack.SlackAlertService
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClientResponseException
@@ -17,10 +17,16 @@ class WebUtilErrorHandler(
         val errorMessage =
             if (error is RestClientResponseException) {
                 val responseBody = error.responseBodyAsString
-                log.error("{} body={}", error, responseBody)
+                log.atError {
+                    message = "{} body={}"
+                    arguments = arrayOf(error, responseBody)
+                }
                 responseBody
             } else {
-                log.error(error.toString(), error)
+                log.atError {
+                    message = error.toString()
+                    cause = error
+                }
                 error.toString()
             }
 
@@ -28,12 +34,15 @@ class WebUtilErrorHandler(
             try {
                 slackAlertService.sendMessage(errorMessage)
             } catch (sendError: Throwable) {
-                log.warn("Failed to send Slack alert", sendError)
+                log.atWarn {
+                    message = "Failed to send Slack alert"
+                    cause = sendError
+                }
             }
         }
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(WebUtilErrorHandler::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/DispatchService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/DispatchService.kt
@@ -1,12 +1,12 @@
 package no.novari.flyt.archive.gateway.dispatch
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.validation.Valid
 import no.novari.flyt.archive.gateway.dispatch.model.CaseDispatchType
 import no.novari.flyt.archive.gateway.dispatch.model.instance.ArchiveInstance
 import no.novari.flyt.archive.gateway.dispatch.model.instance.JournalpostDto
 import no.novari.flyt.archive.gateway.dispatch.sak.CaseDispatchService
 import no.novari.flyt.kafka.instanceflow.headers.InstanceFlowHeaders
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -18,7 +18,10 @@ class DispatchService(
         instanceFlowHeaders: InstanceFlowHeaders,
         @Valid archiveInstance: ArchiveInstance,
     ): DispatchResult {
-        log.info("Dispatching instance with headers={}", instanceFlowHeaders)
+        log.atInfo {
+            message = "Dispatching instance with headers={}"
+            arguments = arrayOf(instanceFlowHeaders)
+        }
 
         val dispatchResult =
             try {
@@ -29,7 +32,11 @@ class DispatchService(
                     null -> DispatchResult.failed("Missing dispatch type")
                 }
             } catch (error: Throwable) {
-                log.error("Failed to dispatch instance with headers={}", instanceFlowHeaders, error)
+                log.atError {
+                    message = "Failed to dispatch instance with headers={}"
+                    arguments = arrayOf(instanceFlowHeaders)
+                    cause = error
+                }
                 throw error
             }
 
@@ -43,18 +50,24 @@ class DispatchService(
     ) {
         when (dispatchResult.status) {
             DispatchStatus.ACCEPTED -> {
-                log.info("Successfully dispatched instance with headers={}", instanceFlowHeaders)
+                log.atInfo {
+                    message = "Successfully dispatched instance with headers={}"
+                    arguments = arrayOf(instanceFlowHeaders)
+                }
             }
 
             DispatchStatus.DECLINED -> {
-                log.info(
-                    "Dispatch was declined for instance with headers={}",
-                    instanceFlowHeaders,
-                )
+                log.atInfo {
+                    message = "Dispatch was declined for instance with headers={}"
+                    arguments = arrayOf(instanceFlowHeaders)
+                }
             }
 
             DispatchStatus.FAILED -> {
-                log.error("Failed to dispatch instance with headers={}", instanceFlowHeaders)
+                log.atError {
+                    message = "Failed to dispatch instance with headers={}"
+                    arguments = arrayOf(instanceFlowHeaders)
+                }
             }
         }
     }
@@ -111,13 +124,16 @@ class DispatchService(
                     }
 
                     archiveCaseIds.isEmpty() -> {
-                        log.info("Found no cases")
+                        log.info { "Found no cases" }
                         processNew(archiveInstance)
                     }
 
                     else -> {
                         val archiveCaseId = archiveCaseIds.first()
-                        log.info("Found case with id='{}'", archiveCaseId)
+                        log.atInfo {
+                            message = "Found case with id='{}'"
+                            arguments = arrayOf(archiveCaseId)
+                        }
 
                         if (!journalpostDtos.isNullOrEmpty()) {
                             recordsProcessingService.processRecords(archiveCaseId, false, journalpostDtos)
@@ -139,6 +155,6 @@ class DispatchService(
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(DispatchService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/file/FileDispatchService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/file/FileDispatchService.kt
@@ -1,12 +1,12 @@
 package no.novari.flyt.archive.gateway.dispatch.file
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.dispatch.file.result.FileDispatchResult
 import no.novari.flyt.archive.gateway.dispatch.isReadTimeout
 import no.novari.flyt.archive.gateway.dispatch.model.instance.DokumentobjektDto
 import no.novari.flyt.archive.gateway.dispatch.web.CreatedLocationPollTimeoutException
 import no.novari.flyt.archive.gateway.dispatch.web.FintArchiveDispatchClient
 import no.novari.flyt.archive.gateway.dispatch.web.flytfile.FlytFileClient
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClientResponseException
 
@@ -16,19 +16,30 @@ class FileDispatchService(
     private val flytFileClient: FlytFileClient,
 ) {
     fun dispatch(dokumentobjektDto: DokumentobjektDto): FileDispatchResult {
-        log.info("Dispatching file")
+        log.info { "Dispatching file" }
         val fileId =
             dokumentobjektDto.fileId
                 ?: return FileDispatchResult.noFileId().also { result ->
-                    log.info("Dispatch result={}", result)
+                    log.atInfo {
+                        message = "Dispatch result={}"
+                        arguments = arrayOf(result)
+                    }
                 }
 
         val file =
             try {
                 flytFileClient.getFile(fileId)
             } catch (error: Throwable) {
-                log.error("File could not be retrieved", error)
-                return FileDispatchResult.couldNotBeRetrieved(fileId).also { log.info("Dispatch result={}", it) }
+                log.atError {
+                    message = "File could not be retrieved"
+                    cause = error
+                }
+                return FileDispatchResult.couldNotBeRetrieved(fileId).also {
+                    log.atInfo {
+                        message = "Dispatch result={}"
+                        arguments = arrayOf(it)
+                    }
+                }
             }
 
         val result =
@@ -38,22 +49,34 @@ class FileDispatchService(
             } catch (error: RestClientResponseException) {
                 FileDispatchResult.declined(fileId, error.responseBodyAsString)
             } catch (error: CreatedLocationPollTimeoutException) {
-                log.error("File dispatch timed out", error)
+                log.atError {
+                    message = "File dispatch timed out"
+                    cause = error
+                }
                 FileDispatchResult.timedOut(fileId)
             } catch (error: Throwable) {
                 if (isReadTimeout(error)) {
-                    log.error("File dispatch timed out", error)
+                    log.atError {
+                        message = "File dispatch timed out"
+                        cause = error
+                    }
                     FileDispatchResult.timedOut(fileId)
                 } else {
-                    log.error("File dispatch failed", error)
+                    log.atError {
+                        message = "File dispatch failed"
+                        cause = error
+                    }
                     FileDispatchResult.failed(fileId)
                 }
             }
-        log.info("Dispatch result={}", result)
+        log.atInfo {
+            message = "Dispatch result={}"
+            arguments = arrayOf(result)
+        }
         return result
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(FileDispatchService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/file/FilesDispatchService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/file/FilesDispatchService.kt
@@ -1,10 +1,10 @@
 package no.novari.flyt.archive.gateway.dispatch.file
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.dispatch.DispatchStatus
 import no.novari.flyt.archive.gateway.dispatch.file.result.FileDispatchResult
 import no.novari.flyt.archive.gateway.dispatch.file.result.FilesDispatchResult
 import no.novari.flyt.archive.gateway.dispatch.model.instance.DokumentobjektDto
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -13,11 +13,11 @@ class FilesDispatchService(
 ) {
     fun dispatch(dokumentobjektDtos: Collection<DokumentobjektDto>): FilesDispatchResult {
         if (dokumentobjektDtos.isEmpty()) {
-            log.info("No files to dispatch")
+            log.info { "No files to dispatch" }
             return FilesDispatchResult.accepted(emptyMap())
         }
 
-        log.info("Dispatching files")
+        log.info { "Dispatching files" }
         val fileDispatchResults = mutableListOf<FileDispatchResult>()
         for (dokumentobjektDto in dokumentobjektDtos) {
             val result = fileDispatchService.dispatch(dokumentobjektDto)
@@ -53,11 +53,14 @@ class FilesDispatchService(
                     FilesDispatchResult.failed()
                 }
             }
-        log.info("Dispatch result={}", result)
+        log.atInfo {
+            message = "Dispatch result={}"
+            arguments = arrayOf(result)
+        }
         return result
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(FilesDispatchService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/journalpost/RecordDispatchService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/journalpost/RecordDispatchService.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.dispatch.journalpost
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.fint.model.resource.Link
 import no.novari.fint.model.resource.arkiv.noark.JournalpostResource
 import no.novari.flyt.archive.gateway.dispatch.DispatchStatus
@@ -12,7 +13,6 @@ import no.novari.flyt.archive.gateway.dispatch.model.instance.DokumentobjektDto
 import no.novari.flyt.archive.gateway.dispatch.model.instance.JournalpostDto
 import no.novari.flyt.archive.gateway.dispatch.web.CreatedLocationPollTimeoutException
 import no.novari.flyt.archive.gateway.dispatch.web.FintArchiveDispatchClient
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClientResponseException
 import java.util.UUID
@@ -27,7 +27,7 @@ class RecordDispatchService(
         caseId: String,
         journalpostDto: JournalpostDto,
     ): RecordDispatchResult {
-        log.info("Dispatching record")
+        log.info { "Dispatching record" }
 
         val dokumentobjektDtos = journalpostDto.dokumentbeskrivelse?.flatMap(this::getDokumentObjektDtos).orEmpty()
         val result =
@@ -51,7 +51,10 @@ class RecordDispatchService(
                     }
                 }
             }
-        log.info("Dispatch result={}", result)
+        log.atInfo {
+            message = "Dispatch result={}"
+            arguments = arrayOf(result)
+        }
         return result
     }
 
@@ -72,20 +75,29 @@ class RecordDispatchService(
         } catch (error: RestClientResponseException) {
             RecordDispatchResult.declined(error.responseBodyAsString)
         } catch (error: CreatedLocationPollTimeoutException) {
-            log.error("Record dispatch timed out", error)
+            log.atError {
+                message = "Record dispatch timed out"
+                cause = error
+            }
             RecordDispatchResult.timedOut()
         } catch (error: Throwable) {
             if (isReadTimeout(error)) {
-                log.error("Record dispatch timed out", error)
+                log.atError {
+                    message = "Record dispatch timed out"
+                    cause = error
+                }
                 RecordDispatchResult.timedOut()
             } else {
-                log.error("Failed to post record", error)
+                log.atError {
+                    message = "Failed to post record"
+                    cause = error
+                }
                 RecordDispatchResult.failed("Failed to post record")
             }
         }
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(RecordDispatchService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/journalpost/RecordsDispatchService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/journalpost/RecordsDispatchService.kt
@@ -1,11 +1,11 @@
 package no.novari.flyt.archive.gateway.dispatch.journalpost
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.dispatch.DispatchMessageFormattingService
 import no.novari.flyt.archive.gateway.dispatch.DispatchStatus
 import no.novari.flyt.archive.gateway.dispatch.journalpost.result.RecordDispatchResult
 import no.novari.flyt.archive.gateway.dispatch.journalpost.result.RecordsDispatchResult
 import no.novari.flyt.archive.gateway.dispatch.model.instance.JournalpostDto
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -17,7 +17,7 @@ class RecordsDispatchService(
         caseId: String,
         journalpostDtos: List<JournalpostDto>,
     ): RecordsDispatchResult {
-        log.info("Dispatching records")
+        log.info { "Dispatching records" }
         if (journalpostDtos.isEmpty()) {
             return RecordsDispatchResult.accepted(emptyList())
         }
@@ -64,13 +64,19 @@ class RecordsDispatchService(
                     }
                 }
             } catch (error: Throwable) {
-                log.error("Journalposts dispatch failed", error)
+                log.atError {
+                    message = "Journalposts dispatch failed"
+                    cause = error
+                }
                 RecordsDispatchResult.failed(
                     "Journalposts dispatch failed",
                     "possible journalposts with unknown ids",
                 )
             }
-        log.info("Dispatch result={}", result)
+        log.atInfo {
+            message = "Dispatch result={}"
+            arguments = arrayOf(result)
+        }
         return result
     }
 
@@ -82,6 +88,6 @@ class RecordsDispatchService(
         )
 
     companion object {
-        private val log = LoggerFactory.getLogger(RecordsDispatchService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/mapping/SakMappingService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/mapping/SakMappingService.kt
@@ -1,9 +1,9 @@
 package no.novari.flyt.archive.gateway.dispatch.mapping
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.fint.model.resource.Link
 import no.novari.fint.model.resource.arkiv.noark.SakResource
 import no.novari.flyt.archive.gateway.dispatch.model.instance.SakDto
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -15,7 +15,7 @@ class SakMappingService(
     fun toSakResource(sakDto: SakDto?): SakResource {
         requireNotNull(sakDto) { "sakDto cannot be null" }
 
-        log.info("Mapping SakDto to SakResource")
+        log.info { "Mapping SakDto to SakResource" }
 
         return SakResource()
             .apply {
@@ -32,11 +32,11 @@ class SakMappingService(
                 sakDto.skjerming?.let(skjermingMappingService::toSkjermingResource)?.let(::setSkjerming)
                 sakDto.klasse?.let(klasseMappingService::toKlasse)?.let(::setKlasse)
             }.also {
-                log.info("Successfully mapped SakDto to SakResource")
+                log.info { "Successfully mapped SakDto to SakResource" }
             }
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(SakMappingService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/sak/CaseDispatchService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/sak/CaseDispatchService.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.dispatch.sak
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.fint.model.felles.kompleksedatatyper.Identifikator
 import no.novari.fint.model.resource.arkiv.noark.SakResource
 import no.novari.flyt.archive.gateway.dispatch.isReadTimeout
@@ -14,7 +15,6 @@ import no.novari.flyt.archive.gateway.resource.web.CaseSearchParametersService
 import no.novari.flyt.archive.gateway.resource.web.FintArchiveResourceClient
 import no.novari.flyt.archive.gateway.resource.web.exceptions.KlasseOrderOutOfBoundsException
 import no.novari.flyt.archive.gateway.resource.web.exceptions.SearchKlasseOrderNotFoundInCaseException
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClientResponseException
 
@@ -26,36 +26,54 @@ class CaseDispatchService(
     private val fintArchiveResourceClient: FintArchiveResourceClient,
 ) {
     fun dispatch(sakDto: SakDto): CaseDispatchResult {
-        log.info("Dispatching case")
+        log.info { "Dispatching case" }
         val sakResource: SakResource = sakMappingService.toSakResource(sakDto)
 
         val result =
             try {
                 val resultSak = fintArchiveDispatchClient.postCase(sakResource)
                 val archiveCaseId = resultSak.mappeId.identifikatorverdi
-                log.info("Successfully posted case with archive case id = {}", archiveCaseId)
+                log.atInfo {
+                    message = "Successfully posted case with archive case id = {}"
+                    arguments = arrayOf(archiveCaseId)
+                }
                 CaseDispatchResult.accepted(archiveCaseId)
             } catch (error: RestClientResponseException) {
-                log.info("Post request for case was declined with message='{}'", error.responseBodyAsString)
+                log.atInfo {
+                    message = "Post request for case was declined with message='{}'"
+                    arguments = arrayOf(error.responseBodyAsString)
+                }
                 CaseDispatchResult.declined(error.responseBodyAsString)
             } catch (error: CreatedLocationPollTimeoutException) {
-                log.error("Case dispatch timed out", error)
+                log.atError {
+                    message = "Case dispatch timed out"
+                    cause = error
+                }
                 CaseDispatchResult.timedOut()
             } catch (error: Throwable) {
                 if (isReadTimeout(error)) {
-                    log.error("Case dispatch timed out", error)
+                    log.atError {
+                        message = "Case dispatch timed out"
+                        cause = error
+                    }
                     CaseDispatchResult.timedOut()
                 } else {
-                    log.error("Failed to post case", error)
+                    log.atError {
+                        message = "Failed to post case"
+                        cause = error
+                    }
                     CaseDispatchResult.failed()
                 }
             }
-        log.info("Dispatch result: {}", result)
+        log.atInfo {
+            message = "Dispatch result: {}"
+            arguments = arrayOf(result)
+        }
         return result
     }
 
     fun findCasesBySearch(archiveInstance: ArchiveInstance): CaseSearchResult {
-        log.info("Searching for cases")
+        log.info { "Searching for cases" }
 
         val caseFilter =
             try {
@@ -63,16 +81,28 @@ class CaseDispatchService(
                 val caseSearchParameters = requireNotNull(archiveInstance.caseSearchParameters)
                 caseSearchParametersService.createFilterQueryParamValue(newCase, caseSearchParameters)
             } catch (error: SearchKlasseOrderNotFoundInCaseException) {
-                log.error("Case search failed", error)
+                log.atError {
+                    message = "Case search failed"
+                    cause = error
+                }
                 return CaseSearchResult.declined(error.message.orEmpty())
             } catch (error: KlasseOrderOutOfBoundsException) {
-                log.error("Case search failed", error)
+                log.atError {
+                    message = "Case search failed"
+                    cause = error
+                }
                 return CaseSearchResult.declined(error.message.orEmpty())
             } catch (error: Exception) {
-                log.error("Case search failed", error)
+                log.atError {
+                    message = "Case search failed"
+                    cause = error
+                }
                 return CaseSearchResult.failed()
             }
-        log.debug("Generated case filter: {}", caseFilter)
+        log.atDebug {
+            message = "Generated case filter: {}"
+            arguments = arrayOf(caseFilter)
+        }
 
         val result =
             try {
@@ -84,18 +114,27 @@ class CaseDispatchService(
                 CaseSearchResult.accepted(ids)
             } catch (error: Throwable) {
                 if (isReadTimeout(error)) {
-                    log.error("Case search timed out", error)
+                    log.atError {
+                        message = "Case search timed out"
+                        cause = error
+                    }
                     CaseSearchResult.timedOut()
                 } else {
-                    log.error("Case search failed", error)
+                    log.atError {
+                        message = "Case search failed"
+                        cause = error
+                    }
                     CaseSearchResult.failed()
                 }
             }
-        log.info("Search result: {}", result)
+        log.atInfo {
+            message = "Search result: {}"
+            arguments = arrayOf(result)
+        }
         return result
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(CaseDispatchService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/web/FintArchiveDispatchClient.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/web/FintArchiveDispatchClient.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.dispatch.web
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import no.novari.fint.model.resource.Link
@@ -9,7 +10,6 @@ import no.novari.flyt.archive.gateway.WebUtilErrorHandler
 import no.novari.flyt.archive.gateway.dispatch.model.File
 import no.novari.flyt.archive.gateway.dispatch.model.JournalpostWrapper
 import no.novari.flyt.archive.gateway.resource.web.FintArchiveResourceClient
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.http.ContentDisposition
 import org.springframework.http.HttpHeaders
@@ -57,7 +57,7 @@ class FintArchiveDispatchClient(
     fun postFile(file: File): Link {
         val sample = Timer.start(meterRegistry)
         try {
-            log.info("Posting file")
+            log.info { "Posting file" }
             val response =
                 fintRestClient
                     .post()
@@ -69,7 +69,10 @@ class FintArchiveDispatchClient(
                     .toBodilessEntity()
             val createdLocation = pollAfterAcceptedResponse(response)
             val link = Link.with(createdLocation.toString())
-            log.info("Successfully posted file name={} uri={}", file.name, createdLocation)
+            log.atInfo {
+                message = "Successfully posted file name={} uri={}"
+                arguments = arrayOf(file.name, createdLocation)
+            }
             return link
         } catch (error: Throwable) {
             webUtilErrorHandler.logAndSendError(error)
@@ -82,7 +85,7 @@ class FintArchiveDispatchClient(
     fun postCase(sakResource: SakResource): SakResource {
         val sample = Timer.start(meterRegistry)
         try {
-            log.info("Posting case")
+            log.info { "Posting case" }
             val response =
                 fintRestClient
                     .post()
@@ -105,7 +108,10 @@ class FintArchiveDispatchClient(
     ): JournalpostResource {
         val sample = Timer.start(meterRegistry)
         try {
-            log.info("Posting record caseId={}", caseId)
+            log.atInfo {
+                message = "Posting record caseId={}"
+                arguments = arrayOf(caseId)
+            }
             val response =
                 fintRestClient
                     .put()
@@ -148,11 +154,10 @@ class FintArchiveDispatchClient(
     }
 
     private fun getStatusLocation(entity: ResponseEntity<Void>): URI {
-        log.debug(
-            "Received status response status={} location={}",
-            entity.statusCode,
-            entity.headers.location,
-        )
+        log.atDebug {
+            message = "Received status response status={} location={}"
+            arguments = arrayOf(entity.statusCode, entity.headers.location)
+        }
         val location = entity.headers.location
         if (entity.statusCode == HttpStatus.ACCEPTED && location != null) {
             return location
@@ -168,13 +173,10 @@ class FintArchiveDispatchClient(
         val minDelay = requireNotNull(properties.createdLocationPollBackoffMinDelay)
         val maxDelay = requireNotNull(properties.createdLocationPollBackoffMaxDelay)
 
-        log.info(
-            "Polling for created location statusUri={} totalTimeout={} backoffMinDelay={} backoffMaxDelay={}",
-            statusUri,
-            totalTimeout,
-            minDelay,
-            maxDelay,
-        )
+        log.atInfo {
+            message = "Polling for created location statusUri={} totalTimeout={} backoffMinDelay={} backoffMaxDelay={}"
+            arguments = arrayOf(statusUri, totalTimeout, minDelay, maxDelay)
+        }
 
         val deadline = Instant.now().plus(totalTimeout)
         var delay = minDelay
@@ -190,12 +192,10 @@ class FintArchiveDispatchClient(
                         .retrieve()
                         .toBodilessEntity()
                 lastStatus = entity.statusCode.toString()
-                log.debug(
-                    "Poll response statusUri={} status={} location={}",
-                    statusUri,
-                    entity.statusCode,
-                    entity.headers.location,
-                )
+                log.atDebug {
+                    message = "Poll response statusUri={} status={} location={}"
+                    arguments = arrayOf(statusUri, entity.statusCode, entity.headers.location)
+                }
                 val location = entity.headers.location
                 if (entity.statusCode == HttpStatus.CREATED && location != null) {
                     return location
@@ -211,17 +211,15 @@ class FintArchiveDispatchClient(
             delay = minOf(delay.multipliedBy(2), maxDelay)
         }
 
-        log.warn(
-            "Timed out polling created location statusUri={} totalTimeout={} lastStatus={}",
-            statusUri,
-            totalTimeout,
-            lastStatus,
-        )
+        log.atWarn {
+            message = "Timed out polling created location statusUri={} totalTimeout={} lastStatus={}"
+            arguments = arrayOf(statusUri, totalTimeout, lastStatus)
+        }
         throw CreatedLocationPollTimeoutException(statusUri, totalTimeout, lastStatus)
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(FintArchiveDispatchClient::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }
 

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/web/flytfile/FlytFileClient.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/dispatch/web/flytfile/FlytFileClient.kt
@@ -1,7 +1,7 @@
 package no.novari.flyt.archive.gateway.dispatch.web.flytfile
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.dispatch.model.File
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
 import org.springframework.web.client.RestClient
@@ -15,7 +15,7 @@ class FlytFileClient(
     private val fileRestClient: RestClient,
 ) {
     fun getFile(fileId: UUID): File {
-        log.info("Getting file")
+        log.info { "Getting file" }
         var attempt = 0
         var delay = INITIAL_RETRY_DELAY
         while (true) {
@@ -28,20 +28,26 @@ class FlytFileClient(
                             .retrieve()
                             .body<File>(),
                     ) { "Empty response body when retrieving file with id=$fileId" }
-                log.info("Retrieved file with id={}", fileId)
+                log.atInfo {
+                    message = "Retrieved file with id={}"
+                    arguments = arrayOf(fileId)
+                }
                 return file
             } catch (error: Throwable) {
                 if (attempt >= MAX_RETRIES) {
-                    log.error("Could not retrieve file with id={}", fileId, error)
+                    log.atError {
+                        message = "Could not retrieve file with id={}"
+                        arguments = arrayOf(fileId)
+                        cause = error
+                    }
                     throw error
                 }
                 attempt++
-                log.warn(
-                    "Could not retrieve file with id={} -- performing retry {}",
-                    fileId,
-                    attempt,
-                    error,
-                )
+                log.atWarn {
+                    message = "Could not retrieve file with id={} -- performing retry {}"
+                    arguments = arrayOf(fileId, attempt)
+                    cause = error
+                }
                 Thread.sleep(delay.toMillis())
                 delay = delay.multipliedBy(2)
             }
@@ -49,7 +55,7 @@ class FlytFileClient(
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(FlytFileClient::class.java)
+        private val log = KotlinLogging.logger {}
         private const val MAX_RETRIES = 5
         private val INITIAL_RETRY_DELAY: Duration = Duration.ofSeconds(1)
     }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/kafka/InstanceMappedEventConsumerConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/kafka/InstanceMappedEventConsumerConfiguration.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.kafka
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.dispatch.DispatchService
 import no.novari.flyt.archive.gateway.dispatch.DispatchStatus
 import no.novari.flyt.archive.gateway.dispatch.model.instance.ArchiveInstance
@@ -10,7 +11,6 @@ import no.novari.kafka.consuming.ErrorHandlerFactory
 import no.novari.kafka.consuming.ListenerConfiguration
 import no.novari.kafka.topic.name.EventTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
@@ -31,14 +31,17 @@ class InstanceMappedEventConsumerConfiguration {
                 ArchiveInstance::class.java,
                 { instanceFlowConsumerRecord ->
                     val consumerRecord = instanceFlowConsumerRecord.consumerRecord
-                    log.info(
-                        "Consumed instance-mapped event topic={} partition={} offset={} key={} headers={}",
-                        consumerRecord.topic(),
-                        consumerRecord.partition(),
-                        consumerRecord.offset(),
-                        consumerRecord.key(),
-                        instanceFlowConsumerRecord.instanceFlowHeaders,
-                    )
+                    log.atInfo {
+                        message = "Consumed instance-mapped event topic={} partition={} offset={} key={} headers={}"
+                        arguments =
+                            arrayOf(
+                                consumerRecord.topic(),
+                                consumerRecord.partition(),
+                                consumerRecord.offset(),
+                                consumerRecord.key(),
+                                instanceFlowConsumerRecord.instanceFlowHeaders,
+                            )
+                    }
                     val dispatchResult =
                         dispatchService.process(
                             instanceFlowConsumerRecord.instanceFlowHeaders,
@@ -97,6 +100,6 @@ class InstanceMappedEventConsumerConfiguration {
             )
 
     companion object {
-        private val log = LoggerFactory.getLogger(InstanceMappedEventConsumerConfiguration::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/resource/CaseRequestConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/resource/CaseRequestConfiguration.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.resource
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.fint.model.resource.arkiv.noark.JournalpostResource
 import no.novari.fint.model.resource.arkiv.noark.SakResource
 import no.novari.flyt.archive.gateway.resource.web.FintArchiveResourceClient
@@ -12,7 +13,6 @@ import no.novari.kafka.requestreply.topic.RequestTopicService
 import no.novari.kafka.requestreply.topic.configuration.RequestTopicConfiguration
 import no.novari.kafka.requestreply.topic.name.RequestTopicNameParameters
 import no.novari.kafka.topic.name.TopicNamePrefixParameters
-import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer
@@ -129,7 +129,11 @@ class CaseRequestConfiguration(
                 fintArchiveResourceClient.getResource("/arkiv/noark/sak/mappeid/$mappeId", SakResource::class.java)
             ReplyProducerRecord.builder<SakResource>().value(sakResource).build()
         } catch (error: RuntimeException) {
-            log.error("Could not find case with id={}", mappeId, error)
+            log.atError {
+                message = "Could not find case with id={}"
+                arguments = arrayOf(mappeId)
+                cause = error
+            }
             ReplyProducerRecord.builder<SakResource>().value(null).build()
         }
 
@@ -151,7 +155,11 @@ class CaseRequestConfiguration(
 
             ReplyProducerRecord.builder<SakResource>().value(sakResource).build()
         } catch (error: RuntimeException) {
-            log.error("Could not find case with archive instance id={}", archiveInstanceId, error)
+            log.atError {
+                message = "Could not find case with archive instance id={}"
+                arguments = arrayOf(archiveInstanceId)
+                cause = error
+            }
             ReplyProducerRecord.builder<SakResource>().value(null).build()
         }
     }
@@ -162,7 +170,7 @@ class CaseRequestConfiguration(
     )
 
     companion object {
-        private val log = LoggerFactory.getLogger(CaseRequestConfiguration::class.java)
+        private val log = KotlinLogging.logger {}
         private val RETENTION_TIME: Duration = Duration.ofMinutes(10)
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/resource/FintResourcePublishingConfiguration.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/resource/FintResourcePublishingConfiguration.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.resource
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.flyt.archive.gateway.resource.configuration.ResourcePipeline
 import no.novari.flyt.archive.gateway.resource.configuration.ResourcePublishingConfigurationProperties
 import no.novari.flyt.archive.gateway.resource.web.FintArchiveResourceClient
@@ -9,7 +10,6 @@ import no.novari.kafka.producing.ParameterizedTemplateFactory
 import no.novari.kafka.topic.EntityTopicService
 import no.novari.kafka.topic.configuration.EntityCleanupFrequency
 import no.novari.kafka.topic.configuration.EntityTopicConfiguration
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Configuration
 import org.springframework.scheduling.annotation.SchedulingConfigurer
@@ -77,12 +77,15 @@ class FintResourcePublishingConfiguration(
             CronTask(
                 {
                     lastUpdatedTimestampForPulledResourcesPerResourcePath.clear()
-                    log.info("Reset last updated timestamp")
+                    log.info { "Reset last updated timestamp" }
                 },
                 cronTrigger,
             ),
         )
-        log.info("Scheduled reset of last updated timestamp at {}", timeOfDayToReset)
+        log.atInfo {
+            message = "Scheduled reset of last updated timestamp at {}"
+            arguments = arrayOf(timeOfDayToReset)
+        }
 
         taskRegistrar.addFixedDelayTask(
             IntervalTask(
@@ -114,9 +117,9 @@ class FintResourcePublishingConfiguration(
     }
 
     private fun pullAllUpdatedResources() {
-        log.info("Starting pulling resources")
+        log.info { "Starting pulling resources" }
         resourcePipelines.forEach(::pullUpdatedResources)
-        log.info("Completed pulling resources")
+        log.info { "Completed pulling resources" }
     }
 
     private fun pullUpdatedResources(resourcePipeline: ResourcePipeline<Any>) {
@@ -129,13 +132,22 @@ class FintResourcePublishingConfiguration(
 
             updatedResources.forEach { resource -> handleResource(resource, resourcePipeline) }
             resourcePipeline.cacheProperties?.let { cacheProperties ->
-                log.info("{} entities cached in {}", updatedResources.size, cacheProperties.cache.alias)
+                log.atInfo {
+                    message = "{} entities cached in {}"
+                    arguments = arrayOf(updatedResources.size, cacheProperties.cache.alias)
+                }
             }
             resourcePipeline.kafkaProperties?.let { kafkaProperties ->
-                log.info("{} entities sent to {}", updatedResources.size, kafkaProperties.topicNameParameters)
+                log.atInfo {
+                    message = "{} entities sent to {}"
+                    arguments = arrayOf(updatedResources.size, kafkaProperties.topicNameParameters)
+                }
             }
         } catch (error: Exception) {
-            log.error("An error occurred processing entities", error)
+            log.atError {
+                message = "An error occurred processing entities"
+                cause = error
+            }
         }
     }
 
@@ -166,7 +178,10 @@ class FintResourcePublishingConfiguration(
         try {
             val lastUpdatedTimestampFromServer = fintArchiveResourceClient.getLastUpdated(urlResourcePath)
             if (lastUpdatedTimestampFromServer == null) {
-                log.warn("Last-updated response was null for {}", urlResourcePath)
+                log.atWarn {
+                    message = "Last-updated response was null for {}"
+                    arguments = arrayOf(urlResourcePath)
+                }
                 return emptyList()
             }
 
@@ -183,12 +198,16 @@ class FintResourcePublishingConfiguration(
             lastUpdatedTimestampForPulledResourcesPerResourcePath[urlResourcePath] = lastUpdatedTimestampFromServer
             resources
         } catch (error: RestClientException) {
-            log.error("Could not pull entities from url resource path={}", urlResourcePath, error)
+            log.atError {
+                message = "Could not pull entities from url resource path={}"
+                arguments = arrayOf(urlResourcePath)
+                cause = error
+            }
             emptyList()
         }
 
     companion object {
-        private val log = LoggerFactory.getLogger(FintResourcePublishingConfiguration::class.java)
+        private val log = KotlinLogging.logger {}
         private const val PARTITIONS = 1
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/resource/web/CaseSearchParametersService.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/resource/web/CaseSearchParametersService.kt
@@ -1,5 +1,6 @@
 package no.novari.flyt.archive.gateway.resource.web
 
+import io.github.oshai.kotlinlogging.KotlinLogging
 import no.novari.cache.FintCache
 import no.novari.fint.model.resource.arkiv.kodeverk.SaksmappetypeResource
 import no.novari.fint.model.resource.arkiv.kodeverk.SaksstatusResource
@@ -12,7 +13,6 @@ import no.novari.flyt.archive.gateway.dispatch.model.instance.KlasseDto
 import no.novari.flyt.archive.gateway.dispatch.model.instance.SakDto
 import no.novari.flyt.archive.gateway.resource.web.exceptions.KlasseOrderOutOfBoundsException
 import no.novari.flyt.archive.gateway.resource.web.exceptions.SearchKlasseOrderNotFoundInCaseException
-import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 
 @Service
@@ -88,8 +88,16 @@ class CaseSearchParametersService(
                                 rekkefolge,
                             )
 
-                    klasseDtoMatchingRekkefolge.rekkefolge?.let { log.debug("KlasseDto rekkefolge: {}", it) }
-                    log.debug("Søkeparametere rekkefølge: {}", rekkefolge)
+                    klasseDtoMatchingRekkefolge.rekkefolge?.let {
+                        log.atDebug {
+                            message = "KlasseDto rekkefolge: {}"
+                            arguments = arrayOf(it)
+                        }
+                    }
+                    log.atDebug {
+                        message = "Søkeparametere rekkefølge: {}"
+                        arguments = arrayOf(rekkefolge)
+                    }
 
                     if (caseSearchParametersDto.getKlasseringKlassifikasjonssystem()) {
                         klasseDtoMatchingRekkefolge.klassifikasjonssystem
@@ -136,6 +144,6 @@ class CaseSearchParametersService(
     }
 
     companion object {
-        private val log = LoggerFactory.getLogger(CaseSearchParametersService::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/kotlin/no/novari/flyt/archive/gateway/resource/web/FintArchiveResourceClient.kt
+++ b/src/main/kotlin/no/novari/flyt/archive/gateway/resource/web/FintArchiveResourceClient.kt
@@ -1,6 +1,7 @@
 package no.novari.flyt.archive.gateway.resource.web
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import io.github.oshai.kotlinlogging.KotlinLogging
 import io.micrometer.core.instrument.MeterRegistry
 import io.micrometer.core.instrument.Timer
 import no.novari.fint.model.resource.AbstractCollectionResources
@@ -8,7 +9,6 @@ import no.novari.fint.model.resource.arkiv.noark.SakResource
 import no.novari.fint.model.resource.arkiv.noark.SakResources
 import no.novari.flyt.archive.gateway.WebUtilErrorHandler
 import no.novari.flyt.archive.gateway.resource.model.ResourceCollection
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.http.MediaType
@@ -76,9 +76,16 @@ class FintArchiveResourceClient(
                 .map { resource -> objectMapper.convertValue(resource, resourceClass) }
         } catch (error: Exception) {
             if (error is RestClientResponseException) {
-                log.error("{} body={}", error, error.responseBodyAsString)
+                log.atError {
+                    message = "{} body={}"
+                    arguments = arrayOf(error, error.responseBodyAsString)
+                }
             } else {
-                log.error("Error fetching resources since {}", sinceTimestamp, error)
+                log.atError {
+                    message = "Error fetching resources since {}"
+                    arguments = arrayOf(sinceTimestamp)
+                    cause = error
+                }
             }
             throw error
         }
@@ -110,11 +117,11 @@ class FintArchiveResourceClient(
                     webUtilErrorHandler.logAndSendError(error)
                     throw error
                 }
-                log.warn(
-                    "Encountered error when finding cases with filter -- performing retry {}",
-                    attempt,
-                    error,
-                )
+                log.atWarn {
+                    message = "Encountered error when finding cases with filter -- performing retry {}"
+                    arguments = arrayOf(attempt)
+                    cause = error
+                }
                 Thread.sleep(delay.toMillis())
                 delay = minOf(delay.multipliedBy(2), maxDelay)
             } finally {
@@ -142,6 +149,6 @@ class FintArchiveResourceClient(
     )
 
     companion object {
-        private val log = LoggerFactory.getLogger(FintArchiveResourceClient::class.java)
+        private val log = KotlinLogging.logger {}
     }
 }

--- a/src/main/resources/application-flyt-kafka.yaml
+++ b/src/main/resources/application-flyt-kafka.yaml
@@ -3,6 +3,8 @@ novari:
     topic:
       domain-context: flyt
     application-id: ${fint.application-id}
+    tracing:
+      enabled: true
 
 spring:
   kafka:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -42,6 +42,9 @@ server:
   max-http-request-header-size: 40KB
 
 spring:
+  application:
+    name: ${fint.application-id}
+
   profiles:
     include:
       - fint-client

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,8 @@
+<configuration scan="true">
+
+    <include resource="no/novari/telemetry/logback-json.xml"/>
+
+    <root level="INFO">
+        <appender-ref ref="TELEMETRY_JSON"/>
+    </root>
+</configuration>


### PR DESCRIPTION
## Summary

- Roll out OpenTelemetry support for HTTP and Kafka by adding `telemetry-starter`, bumping Flyt Kafka/resource-server dependencies, and enabling Kafka tracing.
- Configure `spring.application.name`, tenant telemetry org IDs, and beta-only OTLP endpoint rendering through the kustomize template/script.
- Add structured JSON logging via the telemetry Logback include and migrate existing SLF4J logger usage to `kotlin-logging`.

Validation: `./gradlew check` and `kubectl kustomize` for all overlays.