### PR TITLE
FFS-2278 Overstyr sårbare avhengighetsversjoner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @FINTLabs/flyt_backend

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,7 +4,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       open-pull-requests-limit: 10
@@ -42,7 +42,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       open-pull-requests-limit: 5
@@ -50,7 +50,7 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-          day: wednesday
+          day: monday
           time: "04:30"
           timezone: "Europe/Oslo"
       groups:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ extra["log4j2.version"] = "2.25.5"
 
 dependencies {
     constraints {
-        implementation("at.yawk.lz4:lz4-java:1.11.1") {
+        implementation("at.yawk.lz4:lz4-java:1.11.2") {
             because("Fixes CVE-2026-59949 in the kafka-clients transitive dependency")
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,9 @@ repositories {
     mavenLocal()
 }
 
+extra["jackson-bom.version"] = "2.21.5"
+extra["log4j2.version"] = "2.25.5"
+
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,12 @@ extra["jackson-bom.version"] = "2.21.5"
 extra["log4j2.version"] = "2.25.5"
 
 dependencies {
+    constraints {
+        implementation("at.yawk.lz4:lz4-java:1.11.1") {
+            because("Fixes CVE-2026-59949 in the kafka-clients transitive dependency")
+        }
+    }
+
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-oauth2-client")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,8 +24,8 @@ repositories {
     mavenLocal()
 }
 
-extra["jackson-bom.version"] = "2.21.5"
-extra["log4j2.version"] = "2.25.5"
+extra["jackson-bom.version"] = "2.22.2"
+extra["log4j2.version"] = "2.26.1"
 
 dependencies {
     constraints {


### PR DESCRIPTION
## Sammendrag

Tre endringer, alle på tvers av repoene eid av `flyt_backend`.

### Sårbare avhengighetsversjoner

Overstyrer versjoner som Spring Boot 3.5.16 styrer til sårbare varianter. Alle bumpene er patch-nivå innenfor samme minor.

- `jackson-bom` → 2.21.5
- `log4j2` → 2.25.5

Spring Boot 3.5.16 er siste utgivelse på 3.5-grenen, og verken den eller 4.1.0 inneholder disse fiksene ennå — CVE-ene er nyere enn begge. Derfor overstyring i stedet for oppgradering. Dependabot lager ikke PR selv her, fordi versjonene ikke er deklarert i `build.gradle.kts` men kommer fra BOM-en.

### Dependabot-plan og CODEOWNERS

Dependabot-planen flyttes fra onsdag til mandag, og `.github/CODEOWNERS` legges til med `* @FINTLabs/flyt_backend`.

Se [FFS-2278](https://novari-iks.atlassian.net/browse/FFS-2278).

[FFS-2278]: https://novari-iks.atlassian.net/browse/FFS-2278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ